### PR TITLE
Add markdown import ability to Editor

### DIFF
--- a/portfolio/app/blog/editor/actions.ts
+++ b/portfolio/app/blog/editor/actions.ts
@@ -2,6 +2,8 @@
 
 import { randomUUID } from "node:crypto";
 
+import matter from "gray-matter";
+
 import { getAdminAccess } from "@/lib/blog/auth";
 import { revalidateBlogContent } from "@/lib/blog/cache";
 import { getSupabaseAdminClient } from "@/lib/supabase";
@@ -235,6 +237,95 @@ export async function deletePostAction(slug: string): Promise<ActionResult<null>
   return {
     ok: true,
     data: null,
+  };
+}
+
+export interface ParsedMarkdownImport {
+  title: string;
+  slug: string;
+  description: string;
+  content: string;
+  category: string;
+  tags: string;
+  coverImage: string;
+  status: PostStatus;
+  publishedAt: string;
+}
+
+export async function parseMarkdownForImportAction(
+  formData: FormData,
+): Promise<ActionResult<ParsedMarkdownImport>> {
+  const access = await ensureAdminAccess();
+
+  if (!access.ok) {
+    return access;
+  }
+
+  const file = formData.get("file");
+
+  if (!(file instanceof File) || !file.name.endsWith(".md")) {
+    return { ok: false, error: "A .md file is required." };
+  }
+
+  const raw = await file.text();
+  const { data: fm, content } = matter(raw);
+
+  // Derive title from filename (strip .md extension)
+  const title = file.name.replace(/\.md$/, "").trim();
+
+  // Case-insensitive key lookup for Obsidian-style frontmatter
+  const get = (key: string) => {
+    const match = Object.keys(fm).find((k) => k.toLowerCase() === key.toLowerCase());
+    return match ? fm[match] : undefined;
+  };
+
+  const description = String(get("description") ?? "").trim();
+  const category = String(get("category") ?? "").trim();
+  const statusRaw = String(get("status") ?? "draft").toLowerCase();
+  const status: PostStatus = isPostStatus(statusRaw) ? statusRaw : "draft";
+
+  // Tags may be a YAML array or a comma-separated string
+  const tagsRaw = get("tags");
+  const tags = Array.isArray(tagsRaw)
+    ? (tagsRaw as string[]).join(", ")
+    : String(tagsRaw ?? "");
+
+  // Cover image — decode from a Vercel proxy URL if needed
+  const rawCoverImage = String(get("cover image url") ?? get("cover_image") ?? "").trim();
+  let coverImage = rawCoverImage;
+  if (coverImage) {
+    try {
+      const proxied = new URL(coverImage).searchParams.get("url");
+      if (proxied) coverImage = decodeURIComponent(proxied);
+    } catch {
+      // Not a URL, keep as-is
+    }
+  }
+
+  // Parse published_at → datetime-local string (yyyy-MM-ddTHH:mm) expected by EditorForm
+  const publishedAtRaw = get("published at") ?? get("published_at");
+  let publishedAt = "";
+  if (publishedAtRaw) {
+    const d = new Date(String(publishedAtRaw));
+    if (!Number.isNaN(d.getTime())) {
+      const offsetMs = d.getTimezoneOffset() * 60_000;
+      publishedAt = new Date(d.getTime() - offsetMs).toISOString().slice(0, 16);
+    }
+  }
+
+  return {
+    ok: true,
+    data: {
+      title,
+      slug: slugify(title),
+      description,
+      content: content.trim(),
+      category,
+      tags,
+      coverImage,
+      status,
+      publishedAt,
+    },
   };
 }
 

--- a/portfolio/app/blog/editor/page.tsx
+++ b/portfolio/app/blog/editor/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { forbidden, redirect } from "next/navigation";
 
 import DeletePostButton from "@/app/components/blog/DeletePostButton";
+import ImportMarkdownButton from "@/app/components/blog/ImportMarkdownButton";
 import FadeIn from "@/app/components/ui/FadeIn";
 import { getAdminAccess } from "@/lib/blog/auth";
 import { getAdminPosts } from "@/lib/blog/data";
@@ -41,9 +42,12 @@ export default async function BlogEditorIndexPage() {
                 Review drafts, update published articles, and start a new post.
               </p>
             </div>
-            <Link href="/blog/editor/new" className="btn-accent text-sm">
-              New Post
-            </Link>
+            <div className="flex items-start gap-3">
+              <ImportMarkdownButton />
+              <Link href="/blog/editor/new" className="btn-accent text-sm">
+                New Post
+              </Link>
+            </div>
           </div>
         </FadeIn>
 

--- a/portfolio/app/components/blog/ImportMarkdownButton.tsx
+++ b/portfolio/app/components/blog/ImportMarkdownButton.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { parseMarkdownForImportAction } from "@/app/blog/editor/actions";
+
+const DRAFT_STORAGE_KEY = "blog-editor-draft:new";
+
+export default function ImportMarkdownButton() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setError(null);
+    setLoading(true);
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const result = await parseMarkdownForImportAction(formData);
+
+    setLoading(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      if (inputRef.current) inputRef.current.value = "";
+      return;
+    }
+
+    const { title, slug, description, content, category, tags, coverImage, status, publishedAt } =
+      result.data;
+
+    // Pre-fill the new post editor via the same localStorage key the EditorForm reads on mount
+    window.localStorage.setItem(
+      DRAFT_STORAGE_KEY,
+      JSON.stringify({
+        title,
+        slug,
+        selectedCategory: "",
+        customCategory: category,
+        tags,
+        description,
+        coverImage,
+        status,
+        publishedAt,
+        content,
+      }),
+    );
+
+    router.push("/blog/editor/new");
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        className="btn-ghost text-sm"
+        disabled={loading}
+        onClick={() => inputRef.current?.click()}
+      >
+        {loading ? "Importing…" : "Import Markdown"}
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".md"
+        className="hidden"
+        onChange={handleChange}
+      />
+      {error && <p className="text-body-sm text-red-400">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
Parses Obsidian-style frontmatter (title from filename, case-insensitive keys, YAML tag arrays, cover image URL, published_at) and pre-fills the new post editor via localStorage.